### PR TITLE
Refactor SimStation/SimRTTY with SimTransmitter base class

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,12 @@
 # FluxTune
 Arduino Based Artificial Radio
 
+## Development Environment
+
+This project is developed on Windows using PowerShell. When running terminal commands:
+- Use `;` instead of `&&` for command chaining (PowerShell syntax)
+- Example: `cd ..; git status` instead of `cd .. && git status`
+
 ## Testing
 
 This project includes comprehensive test suites for core components:

--- a/include/sim_rtty.h
+++ b/include/sim_rtty.h
@@ -1,8 +1,7 @@
 #ifndef __SIM_RTTY_H__
 #define __SIM_RTTY_H__
 
-#include "realization.h"
-#include "realizer_pool.h"
+#include "sim_transmitter.h"
 #include "async_rtty.h"
 
 #define MAX_AUDIBLE_FREQ 5000.0
@@ -11,7 +10,7 @@
 #define MARK_FREQ_SHIFT 170.0
 #define SILENT_FREQ 0.1
 
-class SimRTTY : public Realization
+class SimRTTY : public SimTransmitter
 {
 public:
     SimRTTY(RealizerPool *realizer_pool);

--- a/include/sim_rtty.h
+++ b/include/sim_rtty.h
@@ -19,16 +19,9 @@ public:
     
     virtual bool update(Mode *mode);
 
-    virtual bool step(unsigned long time);
+    virtual bool step(unsigned long time);    void realize();
 
-    void realize();
-
-    float _fixed_freq;
-    bool _enabled;
-    float _frequency;
     AsyncRTTY _rtty;
-    bool _active;
-
     int _phase;
 };
 

--- a/include/sim_rtty.h
+++ b/include/sim_rtty.h
@@ -4,11 +4,7 @@
 #include "sim_transmitter.h"
 #include "async_rtty.h"
 
-#define MAX_AUDIBLE_FREQ 5000.0
-#define MIN_AUDIBLE_FREQ 150.0
-
 #define MARK_FREQ_SHIFT 170.0
-#define SILENT_FREQ 0.1
 
 class SimRTTY : public SimTransmitter
 {

--- a/include/sim_station.h
+++ b/include/sim_station.h
@@ -4,10 +4,7 @@
 #include "async_morse.h"
 #include "sim_transmitter.h"
 
-#define MAX_AUDIBLE_FREQ 5000.0
-#define MIN_AUDIBLE_FREQ 150.0
 #define SPACE_FREQUENCY 0.1
-#define SILENT_FREQ 0.1
 
 class SimStation : public SimTransmitter
 {

--- a/include/sim_station.h
+++ b/include/sim_station.h
@@ -2,15 +2,14 @@
 #define __SIM_STATION_H__
 
 #include "async_morse.h"
-#include "realization.h"
-#include "realizer_pool.h"
+#include "sim_transmitter.h"
 
 #define MAX_AUDIBLE_FREQ 5000.0
 #define MIN_AUDIBLE_FREQ 150.0
 #define SPACE_FREQUENCY 0.1
 #define SILENT_FREQ 0.1
 
-class SimStation : public Realization
+class SimStation : public SimTransmitter
 {
 public:
     SimStation(RealizerPool *realizer_pool);

--- a/include/sim_station.h
+++ b/include/sim_station.h
@@ -19,15 +19,9 @@ public:
 
     virtual bool step(unsigned long time);
 
-    void realize();
+    void realize();    virtual void end();
 
-    virtual void end();
-
-    float _fixed_freq;
-    bool _enabled;
-    float _frequency;
     AsyncMorse _morse;
-    bool _active;
     bool _changed;
 };
 

--- a/include/sim_transmitter.h
+++ b/include/sim_transmitter.h
@@ -1,0 +1,16 @@
+#ifndef __SIM_TRANSMITTER_H__
+#define __SIM_TRANSMITTER_H__
+
+#include "realization.h"
+#include "realizer_pool.h"
+
+class SimTransmitter : public Realization
+{
+public:
+    SimTransmitter(RealizerPool *realizer_pool);
+
+protected:
+    // Empty base class for now
+};
+
+#endif

--- a/include/sim_transmitter.h
+++ b/include/sim_transmitter.h
@@ -4,6 +4,11 @@
 #include "realization.h"
 #include "realizer_pool.h"
 
+// Common constants for simulated transmitters
+#define MAX_AUDIBLE_FREQ 5000.0
+#define MIN_AUDIBLE_FREQ 150.0
+#define SILENT_FREQ 0.1
+
 class SimTransmitter : public Realization
 {
 public:
@@ -13,7 +18,7 @@ protected:
     // Common member variables shared by SimStation and SimRTTY
     float _fixed_freq;
     bool _enabled;
-    float _frequency;
+    float _audible_frequency;  // The virtually tuned frequency heard by the user
     bool _active;
 };
 

--- a/include/sim_transmitter.h
+++ b/include/sim_transmitter.h
@@ -10,7 +10,11 @@ public:
     SimTransmitter(RealizerPool *realizer_pool);
 
 protected:
-    // Empty base class for now
+    // Common member variables shared by SimStation and SimRTTY
+    float _fixed_freq;
+    bool _enabled;
+    float _frequency;
+    bool _active;
 };
 
 #endif

--- a/src/sim_rtty.cpp
+++ b/src/sim_rtty.cpp
@@ -12,7 +12,7 @@ SimRTTY::SimRTTY(RealizerPool *realizer_pool) : SimTransmitter(realizer_pool){
 
 bool SimRTTY::begin(unsigned long time, float fixed_freq){
     _fixed_freq = fixed_freq;
-    _frequency = 0.0;
+    _audible_frequency = 0.0;
 
     // attempt to acquire a realizer
     // _realizer = _realizer_pool->get_realizer();
@@ -37,7 +37,7 @@ void SimRTTY::realize(){
     // WaveGen  *wavegen = (WaveGen*)_realizer;
     WaveGen *wavegen = (WaveGen*)_realizer_pool->access_realizer(_realizer);
 
-    if(_frequency > MAX_AUDIBLE_FREQ || _frequency < MIN_AUDIBLE_FREQ){
+    if(_audible_frequency > MAX_AUDIBLE_FREQ || _audible_frequency < MIN_AUDIBLE_FREQ){
         if(_enabled){
             _enabled = false;
             wavegen->set_frequency(SILENT_FREQ, true);
@@ -59,17 +59,15 @@ void SimRTTY::realize(){
 // returns true on successful update
 bool SimRTTY::update(Mode *mode){
     VFO *vfo = (VFO*)mode;
-    _frequency = float(vfo->_frequency) + (vfo->_sub_frequency / 10.0);
+    _audible_frequency = float(vfo->_frequency) + (vfo->_sub_frequency / 10.0);
 
-    // _frequency = abs(_frequency - _fixed_freq);
-    _frequency = _frequency - _fixed_freq;
-
-
+    // _audible_frequency = abs(_audible_frequency - _fixed_freq);
+    _audible_frequency = _audible_frequency - _fixed_freq;
     if(_enabled){
         // WaveGen  *wavegen = (WaveGen*)_realizer;
         WaveGen *wavegen = (WaveGen*)_realizer_pool->access_realizer(_realizer);
-        wavegen->set_frequency(_frequency, true);
-        wavegen->set_frequency(_frequency + MARK_FREQ_SHIFT, false);
+        wavegen->set_frequency(_audible_frequency, true);
+        wavegen->set_frequency(_audible_frequency + MARK_FREQ_SHIFT, false);
     }
 
     realize();

--- a/src/sim_rtty.cpp
+++ b/src/sim_rtty.cpp
@@ -5,7 +5,7 @@
 #include "sim_rtty.h"
 
 // mode is expected to be a derivative of VFO
-SimRTTY::SimRTTY(RealizerPool *realizer_pool) : Realization(realizer_pool){
+SimRTTY::SimRTTY(RealizerPool *realizer_pool) : SimTransmitter(realizer_pool){
     // _realizer = realizer;
     _rtty.start_rtty_message("CQ CQ DE N6CCM K       ", true);
     _active = false;

--- a/src/sim_rtty.cpp
+++ b/src/sim_rtty.cpp
@@ -6,10 +6,8 @@
 
 // mode is expected to be a derivative of VFO
 SimRTTY::SimRTTY(RealizerPool *realizer_pool) : SimTransmitter(realizer_pool){
-    // _realizer = realizer;
+    // Base class now initializes _active, _enabled, _fixed_freq, _frequency
     _rtty.start_rtty_message("CQ CQ DE N6CCM K       ", true);
-    _active = false;
-    _enabled = false;
 }
 
 bool SimRTTY::begin(unsigned long time, float fixed_freq){

--- a/src/sim_station.cpp
+++ b/src/sim_station.cpp
@@ -14,7 +14,7 @@ SimStation::SimStation(RealizerPool *realizer_pool) : SimTransmitter(realizer_po
 
 bool SimStation::begin(unsigned long time, float fixed_freq, const char *message, int wpm){
     _fixed_freq = fixed_freq;
-    _frequency = 0.0;
+    _audible_frequency = 0.0;
 
     // attempt to acquire a realizer
     // _realizer = _realizer_pool->get_realizer();
@@ -35,7 +35,7 @@ void SimStation::realize(){
     // WaveGen  *wavegen = (WaveGen*)_realizer;
     WaveGen *wavegen = (WaveGen*)_realizer_pool->access_realizer(_realizer);
 
-    if(_frequency > MAX_AUDIBLE_FREQ || _frequency < MIN_AUDIBLE_FREQ){
+    if(_audible_frequency > MAX_AUDIBLE_FREQ || _audible_frequency < MIN_AUDIBLE_FREQ){
         if(_enabled){
             _enabled = false;
             wavegen->set_frequency(SILENT_FREQ, true);
@@ -67,17 +67,14 @@ void SimStation::realize(){
 // returns true on successful update
 bool SimStation::update(Mode *mode){
     VFO *vfo = (VFO*)mode;
-    _frequency = float(vfo->_frequency) + (vfo->_sub_frequency / 10.0);
+    _audible_frequency = float(vfo->_frequency) + (vfo->_sub_frequency / 10.0);
 
-    // _frequency = abs(_frequency - _fixed_freq);
-    _frequency = _frequency - _fixed_freq;
-
-    if(_enabled){
+    // _audible_frequency = abs(_audible_frequency - _fixed_freq);
+    _audible_frequency = _audible_frequency - _fixed_freq;    if(_enabled){
         // WaveGen  *wavegen = (WaveGen*)_realizer;
-
         WaveGen *wavegen = (WaveGen*)_realizer_pool->access_realizer(_realizer);
 
-        wavegen->set_frequency(_frequency);
+        wavegen->set_frequency(_audible_frequency);
     }
 
     realize();

--- a/src/sim_station.cpp
+++ b/src/sim_station.cpp
@@ -7,7 +7,7 @@
 #define WAIT_SECONDS 4
 
 // mode is expected to be a derivative of VFO
-SimStation::SimStation(RealizerPool *realizer_pool) : Realization(realizer_pool)
+SimStation::SimStation(RealizerPool *realizer_pool) : SimTransmitter(realizer_pool)
 {
     // _realizer_pool = realizer_pool;
     _active = false;

--- a/src/sim_station.cpp
+++ b/src/sim_station.cpp
@@ -9,9 +9,7 @@
 // mode is expected to be a derivative of VFO
 SimStation::SimStation(RealizerPool *realizer_pool) : SimTransmitter(realizer_pool)
 {
-    // _realizer_pool = realizer_pool;
-    _active = false;
-    _enabled = false;
+    // Base class now initializes _active, _enabled, _fixed_freq, _frequency
 }
 
 bool SimStation::begin(unsigned long time, float fixed_freq, const char *message, int wpm){

--- a/src/sim_transmitter.cpp
+++ b/src/sim_transmitter.cpp
@@ -6,5 +6,5 @@ SimTransmitter::SimTransmitter(RealizerPool *realizer_pool) : Realization(realiz
     _active = false;
     _enabled = false;
     _fixed_freq = 0.0;
-    _frequency = 0.0;
+    _audible_frequency = 0.0;
 }

--- a/src/sim_transmitter.cpp
+++ b/src/sim_transmitter.cpp
@@ -1,0 +1,6 @@
+#include "sim_transmitter.h"
+
+SimTransmitter::SimTransmitter(RealizerPool *realizer_pool) : Realization(realizer_pool)
+{
+    // Empty base class constructor for now
+}

--- a/src/sim_transmitter.cpp
+++ b/src/sim_transmitter.cpp
@@ -2,5 +2,9 @@
 
 SimTransmitter::SimTransmitter(RealizerPool *realizer_pool) : Realization(realizer_pool)
 {
-    // Empty base class constructor for now
+    // Initialize common member variables
+    _active = false;
+    _enabled = false;
+    _fixed_freq = 0.0;
+    _frequency = 0.0;
 }


### PR DESCRIPTION
## Summary
Extracted common functionality from SimStation and SimRTTY into a new SimTransmitter base class to reduce code duplication and improve maintainability.

## Changes
- ✅ Created SimTransmitter base class inheriting from Realization
- ✅ Moved common member variables (_fixed_freq, _enabled, _active, _audible_frequency) to base class
- ✅ Moved common constants (MAX_AUDIBLE_FREQ, MIN_AUDIBLE_FREQ, SILENT_FREQ) to base class  
- ✅ Renamed _frequency to _audible_frequency for clarity
- ✅ Updated SimStation and SimRTTY to inherit from SimTransmitter

## Testing
- ✅ All native unit tests pass
- ✅ Device testing confirms perfect CW and RTTY sound quality
- ✅ No functional changes, pure refactoring

## Next Steps
Ready for Phase 2: Extract common method logic (frequency bounds checking, etc.)