### PR TITLE
Complete static_cast consistency across all SimTransmitter classes

### DIFF
--- a/src/sim_rtty.cpp
+++ b/src/sim_rtty.cpp
@@ -10,11 +10,10 @@ SimRTTY::SimRTTY(RealizerPool *realizer_pool) : SimTransmitter(realizer_pool){
     _rtty.start_rtty_message("CQ CQ DE N6CCM K       ", true);
 }
 
-bool SimRTTY::begin(unsigned long time, float fixed_freq){
-    if(!common_begin(time, fixed_freq))
+bool SimRTTY::begin(unsigned long time, float fixed_freq){    if(!common_begin(time, fixed_freq))
         return false;
 
-    WaveGen *wavegen = (WaveGen*)_realizer_pool->access_realizer(_realizer);
+    WaveGen *wavegen = static_cast<WaveGen*>(_realizer_pool->access_realizer(_realizer));
 
     wavegen->set_frequency(SILENT_FREQ, false);
     wavegen->set_frequency(SILENT_FREQ, true);
@@ -31,16 +30,14 @@ void SimRTTY::realize(){
         return;  // Out of audible range
     }
     
-    WaveGen *wavegen = (WaveGen*)_realizer_pool->access_realizer(_realizer);
+    WaveGen *wavegen = static_cast<WaveGen*>(_realizer_pool->access_realizer(_realizer));
     wavegen->set_active_frequency(_active);
 }
 
 // returns true on successful update
 bool SimRTTY::update(Mode *mode){
-    common_frequency_update(mode);
-
-    if(_enabled){
-        WaveGen *wavegen = (WaveGen*)_realizer_pool->access_realizer(_realizer);
+    common_frequency_update(mode);    if(_enabled){
+        WaveGen *wavegen = static_cast<WaveGen*>(_realizer_pool->access_realizer(_realizer));
         wavegen->set_frequency(_frequency, true);
         wavegen->set_frequency(_frequency + MARK_FREQ_SHIFT, false);
     }

--- a/src/sim_station.cpp
+++ b/src/sim_station.cpp
@@ -14,11 +14,9 @@ SimStation::SimStation(RealizerPool *realizer_pool) : SimTransmitter(realizer_po
 
 bool SimStation::begin(unsigned long time, float fixed_freq, const char *message, int wpm){
     if(!common_begin(time, fixed_freq))
-        return false;
+        return false;    _morse.start_morse(message, wpm, true, WAIT_SECONDS);
 
-    _morse.start_morse(message, wpm, true, WAIT_SECONDS);
-
-    WaveGen *wavegen = (WaveGen*)_realizer_pool->access_realizer(_realizer);
+    WaveGen *wavegen = static_cast<WaveGen*>(_realizer_pool->access_realizer(_realizer));
     wavegen->set_frequency(SPACE_FREQUENCY, false);
 
     return true;
@@ -29,16 +27,14 @@ void SimStation::realize(){
         return;  // Out of audible range
     }
     
-    WaveGen *wavegen = (WaveGen*)_realizer_pool->access_realizer(_realizer);
+    WaveGen *wavegen = static_cast<WaveGen*>(_realizer_pool->access_realizer(_realizer));
     wavegen->set_active_frequency(_active);
 }
 
 // returns true on successful update
 bool SimStation::update(Mode *mode){
-    common_frequency_update(mode);
-
-    if(_enabled){
-        WaveGen *wavegen = (WaveGen*)_realizer_pool->access_realizer(_realizer);
+    common_frequency_update(mode);    if(_enabled){
+        WaveGen *wavegen = static_cast<WaveGen*>(_realizer_pool->access_realizer(_realizer));
         wavegen->set_frequency(_frequency);
     }
 


### PR DESCRIPTION
- Convert all remaining C-style WaveGen casts to static_cast
- Updated 3 instances each in SimStation and SimRTTY
- Maintains consistency with base class casting style
- Improves type safety throughout the inheritance hierarchy
- Final GPT-4 review feedback addressed