### PR TITLE
Feature/adjustable bfo offset

### DIFF
--- a/include/bfo.h
+++ b/include/bfo.h
@@ -1,0 +1,25 @@
+#ifndef __BFO_H__
+#define __BFO_H__
+
+#include "option.h"
+
+// BFO offset range: 0 Hz to 2000 Hz in increments
+#define MIN_BFO_OFFSET 0
+#define MAX_BFO_OFFSET 2000
+#define BFO_INCREMENT 50     // 50 Hz increments for fine control
+
+class BFO : public Option
+{
+public:
+    // constructor
+    BFO(const char *title);
+
+    virtual void next_option();
+    virtual void prev_option();
+    
+    virtual void update_display(HT16K33Disp *display);
+
+private:
+};
+
+#endif

--- a/include/bfo_handler.h
+++ b/include/bfo_handler.h
@@ -1,0 +1,20 @@
+#ifndef __BFO_HANDLER_H__
+#define __BFO_HANDLER_H__
+
+#include <HT16K33Disp.h>
+#include "mode.h"
+#include "mode_handler.h"
+
+class BFOHandler : public ModeHandler
+{
+public:
+    // constructor
+    BFOHandler(Mode * mode);
+
+    virtual bool event_sink(int event, int count);
+    virtual bool event_sink(bool pressed, bool long_pressed);
+
+private:
+};
+
+#endif // __BFO_HANDLER_H__

--- a/include/saved_data.h
+++ b/include/saved_data.h
@@ -8,9 +8,10 @@
 // ##DATA Increment the save data version to force upgraded devices to auto-reset after programming
 // Current save data version
 // On start-up if this differs from the EEPROM value, the data is reset to defaults
-#define SAVE_DATA_VERSION 1
+#define SAVE_DATA_VERSION 2   // Incremented for BFO offset addition
 
 #define DEFAULT_CONTRAST 2
+#define DEFAULT_BFO_OFFSET 700   // 700 Hz default BFO offset for comfortable audio tuning
 
 // the longest possible count of milliseconds
 #define DEFAULT_TIME ((unsigned long)-1)
@@ -21,6 +22,7 @@
 extern byte save_data_version;
 
 extern int option_contrast;
+extern int option_bfo_offset;  // BFO offset in Hz (0-2000)
 
 // // Whether to play sounds
 // extern bool option_sound;
@@ -50,6 +52,7 @@ extern int option_contrast;
 struct SavedData{
 	byte version;
 	int option_contrast;
+	int option_bfo_offset;
 };
 
 extern void load_save_data();

--- a/include/signal_meter.h
+++ b/include/signal_meter.h
@@ -26,8 +26,7 @@
 // - Decrease DECAY_INTERVAL for smoother decay (more CPU usage)
 class SignalMeter
 {
-public:
-    SignalMeter();
+public:    SignalMeter();
     
     void init();
     void add_charge(int charge_amount = DEFAULT_CHARGE);    // Add charge pulse (like electrical charge into capacitor)
@@ -36,6 +35,9 @@ public:
     
     // Legacy method for backward compatibility (now adds charge instead of setting directly)
     void update_signal_strength(int strength);
+    
+    // Test accessor
+    int get_current_strength() const { return _current_strength; }
     
 private:
     void write_leds();    static const int LED_COUNT = 7;

--- a/include/sim_transmitter.h
+++ b/include/sim_transmitter.h
@@ -9,6 +9,11 @@
 #define MIN_AUDIBLE_FREQ 150.0
 #define SILENT_FREQ 0.1
 
+// BFO (Beat Frequency Oscillator) offset for comfortable audio tuning
+// This shifts the audio frequency without affecting signal meter calculations
+// Now dynamically adjustable via option_bfo_offset (0-2000 Hz)
+// #define BFO_OFFSET 700.0   // Replaced by dynamic option_bfo_offset
+
 /**
  * Base class for simulated transmitters (CW/RTTY).
  * Provides common functionality and interface for station simulation.
@@ -16,20 +21,19 @@
 class SimTransmitter : public Realization
 {
 public:
-    SimTransmitter(RealizerPool *realizer_pool);
-    virtual bool step(unsigned long time) = 0;  // Pure virtual - must be implemented by derived classes
+    SimTransmitter(RealizerPool *realizer_pool);    virtual bool step(unsigned long time) = 0;  // Pure virtual - must be implemented by derived classes
     virtual void end();  // Common cleanup logic
     virtual void force_wave_generator_refresh() override;  // Override base class method
+
+#ifdef NATIVE_BUILD
+    // Test-only method to set VFO frequency directly
+    void set_vfo_frequency_for_test(float vfo_freq) { _vfo_freq = vfo_freq; }
+#endif
 
 protected:    // Common utility methods
     bool check_frequency_bounds();  // Returns true if frequency is in audible range
     bool common_begin(unsigned long time, float fixed_freq);  // Common initialization logic
     void common_frequency_update(Mode *mode);  // Common frequency calculation (mode must be VFO)
-    
-#ifdef PLATFORM_NATIVE
-    // Test-only method to set VFO frequency directly
-    void set_vfo_frequency_for_test(float vfo_freq) { _vfo_freq = vfo_freq; }
-#endif
 
     // Common member variables
     float _fixed_freq;  // Target frequency for this station

--- a/native/mock_realization_pool.h
+++ b/native/mock_realization_pool.h
@@ -2,13 +2,14 @@
 #define MOCK_REALIZATION_POOL_H
 
 class Realization;
+class Realizer;
 
-class RealizationPool {
+// Mock for RealizerPool (not RealizationPool!)
+class RealizerPool {
 public:
-    RealizationPool(Realization **realizations, bool *statuses, int nrealizations) {}
-    bool begin(unsigned long time) { return true; }
-    bool step(unsigned long time) { return true; }
-    void end() {}
+    RealizerPool(Realizer **realizers, bool *statuses, int nrealizers) {}
+    int get_realizer() { return 0; }  // Always return first realizer for testing
+    void free_realizer(int realizer_index) {}
     
     // Add any other required methods as needed
 };

--- a/src/bfo.cpp
+++ b/src/bfo.cpp
@@ -1,0 +1,28 @@
+#include "saved_data.h"
+#include "bfo.h"
+#include "utils.h"
+#include "buffers.h"
+
+BFO::BFO(const char *title) : Option(title)
+{
+}
+
+void BFO::next_option(){
+    option_bfo_offset += BFO_INCREMENT;
+    if(option_bfo_offset > MAX_BFO_OFFSET)
+        option_bfo_offset = MAX_BFO_OFFSET;
+}
+
+void BFO::prev_option(){
+    option_bfo_offset -= BFO_INCREMENT;
+    if(option_bfo_offset < MIN_BFO_OFFSET)
+        option_bfo_offset = MIN_BFO_OFFSET;
+}
+
+void BFO::update_display(HT16K33Disp *display){
+#ifndef DISABLE_DISPLAY_OPERATIONS
+    // No hardware adjustment needed for BFO (unlike contrast which affects display hardware)
+    sprintf(display_text_buffer, "%d Hz", option_bfo_offset);
+    display->scroll_string(display_text_buffer, 1, 1);
+#endif
+}

--- a/src/bfo_handler.cpp
+++ b/src/bfo_handler.cpp
@@ -1,0 +1,27 @@
+#include "bfo.h"
+#include "bfo_handler.h"
+#include "saved_data.h"
+
+BFOHandler::BFOHandler(Mode * mode) : ModeHandler(mode) 
+{
+}
+
+// does mode-specific handling of the event to modify the mode
+// returns true if event was consumed
+bool BFOHandler::event_sink(int event, int event_data){
+    BFO *bfo = (BFO*) _mode;
+
+    if(event == 1){
+        bfo->next_option();
+    } else if(event == -1){
+        bfo->prev_option();
+    }
+
+    save_data();
+
+    return true;
+}
+
+bool BFOHandler::event_sink(bool pressed, bool long_pressed){
+    return false;
+}

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -32,6 +32,8 @@
 
 #include "contrast.h"
 #include "contrast_handler.h"
+#include "bfo.h"
+#include "bfo_handler.h"
 
 #include "wavegen.h"
 #include "wave_out.h"
@@ -323,6 +325,7 @@ VFO vfoe("CHAN 2", 100.0, 10L, &realization_pool);
 VFO vfof("CHAN 3", 1000000.0, 100L, &realization_pool);
 
 Contrast contrast("Contrast");
+BFO bfo("BFO");
 
 VFO_Tuner tunera(&vfoa);
 VFO_Tuner tunerb(&vfob);
@@ -333,14 +336,15 @@ VFO_Tuner tunere(&vfoe);
 VFO_Tuner tunerf(&vfof);
 
 ContrastHandler contrast_handler(&contrast);
+BFOHandler bfo_handler(&bfo);
 
 ModeHandler *handlers1[3] = {&tunera, &tunerb, &tunerc};
 ModeHandler *handlers2[3] = {&tunerd, &tunere, &tunerf};
-ModeHandler *handlers3[1] = {&contrast_handler};
+ModeHandler *handlers3[2] = {&contrast_handler, &bfo_handler};
 
 EventDispatcher dispatcher1(handlers1, 3);
 EventDispatcher dispatcher2(handlers2, 3);
-EventDispatcher dispatcher3(handlers3, 1);
+EventDispatcher dispatcher3(handlers3, 2);
 
 EventDispatcher * dispatcher = &dispatcher1;
 int current_dispatcher = 1;

--- a/src/saved_data.cpp
+++ b/src/saved_data.cpp
@@ -8,6 +8,7 @@
 #include "../include/saved_data.h"
 
 int option_contrast = DEFAULT_CONTRAST;
+int option_bfo_offset = DEFAULT_BFO_OFFSET;
 
 void load_save_data(){
 	SavedData saved_data;
@@ -19,6 +20,7 @@ void load_save_data(){
 	}
 
 	option_contrast = saved_data.option_contrast;
+	option_bfo_offset = saved_data.option_bfo_offset;
 	// option_clock_24h = saved_data.option_clock_24h;
 	// option_idle_mode = saved_data.option_idle_mode;
 	// // bank = saved_data.bank;
@@ -37,10 +39,10 @@ void load_save_data(){
 	// ##DATA Load new persisted play data variables into memory here
 }
 
-void save_data(){
-	SavedData saved_data;
+void save_data(){	SavedData saved_data;
 	saved_data.version = SAVE_DATA_VERSION;
 	saved_data.option_contrast = option_contrast;
+	saved_data.option_bfo_offset = option_bfo_offset;
 
 	EEPROM.put(0, saved_data);
 }
@@ -59,6 +61,7 @@ void reset_device(){
 
 bool reset_options(){
 	option_contrast = DEFAULT_CONTRAST;
+	option_bfo_offset = DEFAULT_BFO_OFFSET;
 
 	save_data();
 

--- a/src/sim_transmitter.cpp
+++ b/src/sim_transmitter.cpp
@@ -1,6 +1,7 @@
 #include "sim_transmitter.h"
 #include "wavegen.h"
 #include "vfo.h"
+#include "saved_data.h"  // For option_bfo_offset
 
 SimTransmitter::SimTransmitter(RealizerPool *realizer_pool) : Realization(realizer_pool)
 {
@@ -24,7 +25,12 @@ void SimTransmitter::common_frequency_update(Mode *mode)
     // Note: mode is expected to be a VFO object
     VFO *vfo = static_cast<VFO*>(mode);
     _vfo_freq = float(vfo->_frequency) + (vfo->_sub_frequency / 10.0);
-    _frequency = _vfo_freq - _fixed_freq;
+    
+    // Calculate raw frequency difference (used for signal meter - no BFO offset)
+    float raw_frequency = _vfo_freq - _fixed_freq;
+      // Add BFO offset for comfortable audio tuning
+    // This shifts the audio frequency without affecting signal meter calculations
+    _frequency = raw_frequency + option_bfo_offset;
 }
 
 bool SimTransmitter::check_frequency_bounds()

--- a/src/vfo.cpp
+++ b/src/vfo.cpp
@@ -82,17 +82,22 @@ int VFO::calculate_signal_charge(float station_freq, float vfo_freq) {
     float freq_diff = abs(vfo_freq - station_freq);
     
     // Signal strength calculation:
-    // - Charge from stations within audible range (±2500 Hz)
-    // - More charge for closer proximity
-    // - Uses same logic as the original VFO charge pulse system
+    // - Charge from stations within wider range (±2500 Hz) for easier tuning
+    // - Much reduced charge amounts for better proportionality
+    // - Comfortable tuning bandwidth with gentle response
     
-    if (freq_diff <= 2500.0) {
+    const float MAX_RANGE = 2500.0;  // Wider range for comfortable tuning
+    
+    if (freq_diff <= MAX_RANGE) {
         // Calculate proximity factor (0.0 to 1.0)
-        float proximity = 1.0 - (freq_diff / 2500.0);
+        float proximity = 1.0 - (freq_diff / MAX_RANGE);
         
-        // Convert proximity to charge amount
-        // Closer stations contribute more charge
-        int charge = (int)(proximity * 12.0);  // 0-12 charge amount
+        // Apply squared curve for realistic but not too steep falloff
+        proximity = proximity * proximity;
+        
+        // Convert proximity to charge amount (much reduced for proportionality)
+        // Lower charge amounts prevent meter from jumping too high
+        int charge = (int)(proximity * 2.0);  // 0-2 charge amount (much reduced)
         
         return charge;
     }

--- a/test/test_signal_meter_carrier_integration.cpp
+++ b/test/test_signal_meter_carrier_integration.cpp
@@ -1,14 +1,8 @@
 #include "unity.h"
+#include "../native/mock_arduino.h"   // Must be first for byte typedef
 #include "signal_meter.h"
 #include "sim_station.h"
-#include "realizer_pool.h"
-#include "mock_realization_pool.h"
-
-#ifdef PLATFORM_NATIVE
-#include "mock_arduino.h"
-#else
-#include <Arduino.h>
-#endif
+#include "../native/mock_realization_pool.h"
 
 void setUp(void) {
     // This is run before EACH test
@@ -21,21 +15,20 @@ void tearDown(void) {
 void test_station_sends_charge_pulse_on_carrier_turn_on(void) {
     // Setup signal meter
     SignalMeter signal_meter;
-    signal_meter.begin();
+    signal_meter.init();
     
     // Setup mock realizer pool
-    MockRealizationPool realizer_pool;
+    RealizerPool realizer_pool(nullptr, nullptr, 0);
     
     // Create station with signal meter
     SimStation station(&realizer_pool, &signal_meter);
     
     // Initialize station
     station.begin(0, 7002000.0, "E", 20); // Short message, 20 WPM
-      // Set VFO frequency close to station for maximum charge
+    // Set VFO frequency close to station for maximum charge
     station.set_vfo_frequency_for_test(7002000.0); // Exact match
-    
-    // Initial signal meter should be at 0
-    signal_meter.step(0);
+      // Initial signal meter should be at 0
+    signal_meter.update(0);
     TEST_ASSERT_EQUAL(0, signal_meter.get_current_strength());
     
     // Step the station - should eventually get TURN_ON event
@@ -46,7 +39,7 @@ void test_station_sends_charge_pulse_on_carrier_turn_on(void) {
         unsigned long time = i * 10; // 10ms steps
         
         // Step signal meter to handle decay
-        signal_meter.step(time);
+        signal_meter.update(time);
         
         // Step station
         station.step(time);
@@ -63,23 +56,23 @@ void test_station_sends_charge_pulse_on_carrier_turn_on(void) {
 void test_station_no_charge_when_vfo_far_away(void) {
     // Setup signal meter
     SignalMeter signal_meter;
-    signal_meter.begin();
+    signal_meter.init();
     
     // Setup mock realizer pool
-    MockRealizationPool realizer_pool;
+    RealizerPool realizer_pool(nullptr, nullptr, 0);
     
     // Create station with signal meter
     SimStation station(&realizer_pool, &signal_meter);
     
     // Initialize station
     station.begin(0, 7002000.0, "E", 20); // Short message, 20 WPM
-      // Set VFO frequency very far from station (no charge expected)
+    // Set VFO frequency very far from station (no charge expected)
     station.set_vfo_frequency_for_test(3500000.0); // Way off frequency
     
     // Step the station and signal meter
     for (int i = 0; i < 1000; i++) {
         unsigned long time = i * 10;
-        signal_meter.step(time);
+        signal_meter.update(time);
         station.step(time);
     }
     

--- a/test/test_vfo_signal_charge.cpp
+++ b/test/test_vfo_signal_charge.cpp
@@ -1,0 +1,116 @@
+#include "unity.h"
+#include "../native/mock_arduino.h"   // Must be first for byte typedef
+#include "vfo.h"
+
+void setUp(void) {
+    // This is run before EACH test
+}
+
+void tearDown(void) {
+    // This is run after EACH test
+}
+
+void test_vfo_charge_calculation_exact_match(void) {
+    // Test charge calculation when VFO exactly matches station frequency
+    float station_freq = 7002000.0;
+    float vfo_freq = 7002000.0;
+    
+    int charge = VFO::calculate_signal_charge(station_freq, vfo_freq);
+    
+    // Should get maximum charge (2) when exactly tuned
+    TEST_ASSERT_EQUAL(2, charge);
+}
+
+void test_vfo_charge_calculation_close_frequency(void) {
+    // Test charge calculation when VFO is close to station frequency
+    float station_freq = 7002000.0;
+    float vfo_freq = 7002500.0;  // 500 Hz away
+    
+    int charge = VFO::calculate_signal_charge(station_freq, vfo_freq);
+    
+    // Should get some charge (>0 but <2) when close
+    TEST_ASSERT_GREATER_THAN(0, charge);
+    TEST_ASSERT_LESS_THAN(2, charge);
+}
+
+void test_vfo_charge_calculation_far_frequency(void) {
+    // Test charge calculation when VFO is far from station frequency
+    float station_freq = 7002000.0;
+    float vfo_freq = 3500000.0;  // Way off frequency
+    
+    int charge = VFO::calculate_signal_charge(station_freq, vfo_freq);
+    
+    // Should get no charge when far away
+    TEST_ASSERT_EQUAL(0, charge);
+}
+
+void test_vfo_charge_calculation_edge_of_range(void) {
+    // Test charge calculation at the edge of the range (±2500 Hz)
+    float station_freq = 7002000.0;
+    float vfo_freq = 7004500.0;  // Exactly 2500 Hz away
+    
+    int charge = VFO::calculate_signal_charge(station_freq, vfo_freq);
+    
+    // Should get minimal charge at edge of range
+    TEST_ASSERT_GREATER_OR_EQUAL(0, charge);
+    TEST_ASSERT_LESS_OR_EQUAL(1, charge);
+}
+
+void test_vfo_charge_calculation_just_outside_range(void) {
+    // Test charge calculation just outside the range
+    float station_freq = 7002000.0;
+    float vfo_freq = 7004501.0;  // Just over 2500 Hz away
+    
+    int charge = VFO::calculate_signal_charge(station_freq, vfo_freq);
+    
+    // Should get no charge outside range
+    TEST_ASSERT_EQUAL(0, charge);
+}
+
+void test_vfo_charge_calculation_with_new_parameters(void) {
+    // Test that with the new parameters (wider range, lower charge), 
+    // we get reasonable values
+    
+    float station_freq = 7002000.0;
+    
+    // Test various distances
+    struct {
+        float freq_offset;
+        int expected_min;
+        int expected_max;
+    } test_cases[] = {
+        {0.0,      2, 2},    // Exact match - max charge
+        {100.0,    1, 2},    // Very close - high charge
+        {500.0,    1, 2},    // Close - medium charge
+        {1000.0,   0, 1},    // Medium distance - low charge
+        {2000.0,   0, 1},    // Far but in range - minimal charge
+        {2500.0,   0, 0},    // Edge of range - minimal or no charge
+        {3000.0,   0, 0},    // Out of range - no charge
+    };
+    
+    for (int i = 0; i < 7; i++) {
+        float vfo_freq = station_freq + test_cases[i].freq_offset;
+        int charge = VFO::calculate_signal_charge(station_freq, vfo_freq);
+        
+        char msg[100];
+        sprintf(msg, "Offset %.1f Hz: charge %d not in range [%d, %d]", 
+                test_cases[i].freq_offset, charge, 
+                test_cases[i].expected_min, test_cases[i].expected_max);
+        
+        TEST_ASSERT_GREATER_OR_EQUAL_MESSAGE(test_cases[i].expected_min, charge, msg);
+        TEST_ASSERT_LESS_OR_EQUAL_MESSAGE(test_cases[i].expected_max, charge, msg);
+    }
+}
+
+int main(void) {
+    UNITY_BEGIN();
+    
+    RUN_TEST(test_vfo_charge_calculation_exact_match);
+    RUN_TEST(test_vfo_charge_calculation_close_frequency);
+    RUN_TEST(test_vfo_charge_calculation_far_frequency);
+    RUN_TEST(test_vfo_charge_calculation_edge_of_range);
+    RUN_TEST(test_vfo_charge_calculation_just_outside_range);
+    RUN_TEST(test_vfo_charge_calculation_with_new_parameters);
+    
+    return UNITY_END();
+}


### PR DESCRIPTION
🎯 Core Features:

Adjustable BFO offset (0-2000 Hz, 50 Hz increments)
Signal meter responding to actual RF proximity
Menu integration with Contrast-style interface
🔧 Technical Implementation:

Complete BFO option system ([bfo.h](vscode-file://vscode-app/c:/Users/jhogs/AppData/Local/Programs/Microsoft%20VS%20Code/resources/app/out/vs/code/electron-sandbox/workbench/workbench.html), [bfo_handler.h](vscode-file://vscode-app/c:/Users/jhogs/AppData/Local/Programs/Microsoft%20VS%20Code/resources/app/out/vs/code/electron-sandbox/workbench/workbench.html), implementations)
EEPROM persistence with version bump (v1→v2)
Dynamic BFO usage in audio frequency calculations
🧪 Testing & Validation:

Native test suite for signal charge calculations
Verified on actual device with 500 Hz preference
Smooth integration with existing codebase